### PR TITLE
Add new flag package

### DIFF
--- a/cmd/anonymize-mysqldump/anonymize-mysqldump.go
+++ b/cmd/anonymize-mysqldump/anonymize-mysqldump.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/DekodeInteraktiv/go-anonymize-mysqldump/internal/anonymize"
+	"github.com/DekodeInteraktiv/anonymize-mysqldump/internal/anonymize"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/DekodeInteraktiv/go-anonymize-mysqldump
+module github.com/DekodeInteraktiv/anonymize-mysqldump
 
 go 1.17
 
 require (
-	github.com/akamensky/argparse v0.0.0-20191006154803-1427fe674291
+	github.com/spf13/pflag v1.0.5
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	syreclabs.com/go/faker v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/akamensky/argparse v0.0.0-20191006154803-1427fe674291 h1:EQ9p1v9+urDzbGQfAcBf9fGuDtYqFNE7YJHZ54TWPTk=
-github.com/akamensky/argparse v0.0.0-20191006154803-1427fe674291/go.mod h1:pdh+2piXurh466J9tqIqq39/9GO2Y8nZt6Cxzu18T9A=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 syreclabs.com/go/faker v1.2.0 h1:fy5UfSu5bOFrVpBk8I1jSgPdOLMJxM7ulKFvkh673ow=

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DekodeInteraktiv/go-anonymize-mysqldump/internal/helpers"
+	"github.com/DekodeInteraktiv/anonymize-mysqldump/internal/flag"
+	"github.com/DekodeInteraktiv/anonymize-mysqldump/internal/helpers"
 
-	"github.com/akamensky/argparse"
 	"github.com/xwb1989/sqlparser"
 )
 
@@ -46,7 +46,8 @@ var (
 )
 
 func Start() {
-	config := parseArgs()
+	configFile := flag.Parse()
+	config := readConfigFile(*configFile)
 
 	lines := setupAndProcessInput(config, os.Stdin)
 
@@ -71,21 +72,6 @@ func setupAndProcessInput(config Config, input io.Reader) chan chan string {
 	}()
 
 	return lines
-}
-
-func parseArgs() Config {
-	parser := argparse.NewParser("anonymize-mysqldump", "Reads SQL from STDIN and replaces content for anonymity based on the provided config.")
-	configFilePath := parser.String("c", "config", &argparse.Options{Required: true, Help: "Path to config.json"})
-
-	err := parser.Parse(os.Args)
-	if err != nil {
-		// In case of error print error and print usage
-		// This can also be done by passing -h or --help flags
-		fmt.Print(parser.Usage(err))
-		os.Exit(1)
-	}
-
-	return readConfigFile(*configFilePath)
 }
 
 func readConfigFile(filepath string) Config {

--- a/internal/anonymize/anonymize_test.go
+++ b/internal/anonymize/anonymize_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/DekodeInteraktiv/go-anonymize-mysqldump/internal/helpers"
+	"github.com/DekodeInteraktiv/anonymize-mysqldump/internal/helpers"
 
 	"syreclabs.com/go/faker"
 )

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -1,0 +1,40 @@
+package flag
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	helpText = `Anonymize MySQLDump is a database anonymization tool.
+
+Usage:
+  anonymize-mysqldump [flags]
+
+Flags:
+  --help -h      Outputs help text and exits.
+  --config -c    The path to a custom config file.
+
+Config:
+  The anonymizer will use a default config suitable for WordPress, but you can override this by providing your own.`
+)
+
+func Parse() *string {
+	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	flagConfigFile := pflag.String("config", "", "Path to config file.")
+	flagHelp := pflag.BoolP("help", "h", false, "")
+
+	pflag.Parse()
+
+	if *flagHelp {
+		fmt.Println(helpText)
+		os.Exit(1)
+	}
+
+	return flagConfigFile
+}


### PR DESCRIPTION
* Adds new `flag` package using the stdlib, removing argparser as a dependency.
* Fixed the github repo URL being wrong in the mod file and internal imports.

Reason for replacing `akamensky/argparse`:
This replaces a little used third party package with a frequently used library which only slightly extends the stdlib, and has been stable for years. This allows us to stay as close to the stdlib as possible, only extending where necessary. The new code should be much easier to grok and work with.