### PR TITLE
Process tableName as either text or regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ An example config for anonymizing a WordPress database is provided at [`config.e
 The config is composed of many objects in the `patterns` array:
 
 - `patterns`: an array of objects defining what modifications should be made.
-  - `tableName`: the name of the table the data will be stored in (used to parse `INSERT` statements to d	etermine if the query should be modified.)
-  - `tableNameRegex`: regex to identify the relevant tables, required for multisite compatibility e.g. `.*_comments`.
+  - `tableName`: the name of the table the data will be stored in (used to parse `INSERT` statements to determine if the query should be modified.). You can also use regex to identify the relevant tables, required for multisite compatibility e.g. `.*_comments`.
   - `fields`: an array of objects defining modifications to individual values' fields
     - `field`: a string representing the name of the field. Not currently used, but still required to work and useful for debugging.
     - `position`: the 1-based index of what number column this field represents. For instance, assuming a table with 3 columns `foo`, `bar`, and `baz`, and you wished to modify the `bar` column, this value would be `2`.

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,7 @@
 {
   "patterns": [
     {
-      "tableName": "wp_users",
+      "tableName": ".*_users",
       "fields": [
         {
           "field": "user_login",
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "tableName": "wp_usermeta",
+      "tableName": ".*_usermeta",
       "fields": [
         {
           "field": "meta_value",
@@ -95,8 +95,7 @@
       ]
     },
     {
-      "tableName": "wp_comments",
-      "tableNameRegex": ".*_comments",
+      "tableName": ".*_comments",
       "fields": [
         {
           "field": "comment_author",

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -229,8 +229,9 @@ func applyConfigToInserts(stmt *sqlparser.Insert, config config.Config) (*sqlpar
 				continue
 			}
 		} else {
-			if stmt.Table.Name.String() != pattern.TableName {
-				// Config is not for this table, move onto next available config
+			re := regexp.MustCompile(pattern.TableName)
+			match := re.MatchString(stmt.Table.Name.String())
+			if !match {
 				continue
 			}
 		}

--- a/internal/embed/files/config.default.json
+++ b/internal/embed/files/config.default.json
@@ -1,7 +1,7 @@
 {
   "patterns": [
     {
-      "tableName": "wp_users",
+      "tableName": ".*_users",
       "fields": [
         {
           "field": "user_login",
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "tableName": "wp_usermeta",
+      "tableName": ".*_usermeta",
       "fields": [
         {
           "field": "meta_value",
@@ -95,8 +95,7 @@
       ]
     },
     {
-      "tableName": "wp_comments",
-      "tableNameRegex": ".*_comments",
+      "tableName": ".*_comments",
       "fields": [
         {
           "field": "comment_author",


### PR DESCRIPTION
Processes `tableName` as regex, still tries `tableNameRegex` first in case it is still being used.