### PR TITLE
fix: use strict regex to validate table name

### DIFF
--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -233,7 +233,7 @@ func applyConfigToInserts(stmt *sqlparser.Insert, config config.Config) (*sqlpar
 				continue
 			}
 		} else {
-			re := regexp.MustCompile(pattern.TableName)
+			re := regexp.MustCompile(fmt.Sprintf("^%s$", pattern.TableName))
 			match := re.MatchString(stmt.Table.Name.String())
 			if !match {
 				continue


### PR DESCRIPTION
## Short introduction
This change will fix the problem as described in #23. 

## Description
This change will fix the problem as described in #23. 
I had the exact same issue and with some debugging, I found out that when the pattern table name does match the statement table name, although it is not an exact match. 
For example, pattern table name "y" does match a statement table name like "x_y".
Therefore the regex MatchString should be more strict and match only when the table names does exactly match.

## Steps to test / reproduce
Create a mysql dump with both tables, "x_y" and "y".
Add a config object with "y" as tableName.
Anonymize the mysql dump.