### PR TITLE
Introduce `WPDateTime` and `WPFutureDateTime`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supposing you have a WordPress database and you need to modify certain meta, be 
 
 Each column stores a certain type of data, be it a name, username, email, etc. The `type` property in the config is used to define the type of data stored, and ultimately the type of random data to be inserted into the field. [https://github.com/dmgk/faker](https://github.com/dmgk/faker) is used for generating the fake data. These are the types currently supported:
 
-| Type                   | Example output                                                                                                                                                                                                                  |
+| Type                   | Example output                                                                                                                                                                                                                  | 
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `username`             | `micah_pfeffer`                                                                                                                                                                                                                 |
 | `password`             | `5ccf672d5c73748146be6b37568efa57`                                                                                                                                                                                              |
@@ -168,6 +168,8 @@ Each column stores a certain type of data, be it a name, username, email, etc. T
 | `creditCardExpiryDate` | `2015-11-11`                                                                                                                                                                                                                    |
 | `creditCardType`       | `mastercard`                                                                                                                                                                                                                    |
 | `norwegianSSN`         | `07026765743`                                                                                                                                                                                                                   |
+| `WPDateTime`           | `2006-01-02 15:04:05`<br>Generates a random datetime +/- 12 years.                                                                                                                                                              |
+| `WPFutureDateTime`     | `2006-01-02 15:04:05`<br>Generates a random future datetime up to +12 years.                                                                                                                                                    |
 | `purge`                |                                                                                                                                                                                                                                 |
 
 If you need another type, please feel free to add support and file a PR!

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -3,7 +3,9 @@ package helpers
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/xwb1989/sqlparser"
 	"syreclabs.com/go/faker"
@@ -50,6 +52,8 @@ func GetFakerFuncs() map[string]func(*sqlparser.SQLVal) *sqlparser.SQLVal {
 		"creditCardExpiryDate": generateCreditCardExpiryDate,
 		"creditCardType":       generateCreditCardType,
 		"norwegianSSN":         generateNorwegianSSN,
+		"WPDateTime":           generateWPDateTime,
+		"WPFutureDateTime":     generateWPFutureDateTime,
 		"purge":                generateEmptyString,
 	}
 
@@ -195,4 +199,37 @@ func generateEmptyString(value *sqlparser.SQLVal) *sqlparser.SQLVal {
 
 func generateNorwegianSSN(value *sqlparser.SQLVal) *sqlparser.SQLVal {
 	return sqlparser.NewStrVal([]byte(generateFakeNorwegianSSN(faker.Date().Birthday(18, 90))))
+}
+
+func generateWPDateTime(value *sqlparser.SQLVal) *sqlparser.SQLVal {
+	// Define the maximum duration in the future/past.
+	// 11 years, 365 days, 24 hours, etc.
+	maxSeconds := int64(11 * 365 * 24 * 60 * 60)
+
+	// Generate a random number of seconds to add
+	randomSeconds := rand.Int63n(maxSeconds)
+
+	var futureTime time.Time
+
+	// Randomize if we add or remove time.
+	if rand.Intn(2) == 0 {
+		futureTime = time.Now().Add(time.Duration(randomSeconds) * time.Second)
+	} else {
+		futureTime = time.Now().Add(-time.Duration(randomSeconds) * time.Second)
+	}
+
+	return sqlparser.NewStrVal([]byte(futureTime.Format("2006-01-02 15:04:05")))
+}
+func generateWPFutureDateTime(value *sqlparser.SQLVal) *sqlparser.SQLVal {
+	// Define the maximum duration in the future.
+	// 11 years, 365 days, 24 hours, etc.
+	maxSeconds := int64(11 * 365 * 24 * 60 * 60)
+
+	// Generate a random number of seconds to add
+	randomSeconds := rand.Int63n(maxSeconds)
+
+	// Add the random duration to the current time
+	futureTime := time.Now().Add(time.Duration(randomSeconds) * time.Second)
+
+	return sqlparser.NewStrVal([]byte(futureTime.Format("2006-01-02 15:04:05")))
 }


### PR DESCRIPTION
This PR adds two new supported custom fake value morphs. These take on the DateTime format used by WordPress (so without timezone offset or similar) as `2006-01-02 15:04:05`, and fit in with needs for changing registration dates, post dates, or similar.

- `WPDateTime` will return a date time +/- 12 years
- `WPFutureDateTime` will return a date time up to +12 years, for when you need to ensure a future date.

See also #30 