### PR TITLE
Add support for negative lookups to constraints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The config is composed of many objects in the `patterns` array:
       - `field`: a string representing the name of the field.
       - `position`: the 1-based index of what number column this field represents. For instance, assuming a table with 3 columns `foo`, `bar`, and `baz`, and you wished to modify the `bar` column, this value would be `2`.
       - `value`: string value to match against.
-      - `compare`: An optional string stating how to treat the constraints. Passing `not like` will make it a negative lookup, and if the `value` matches, this line will not be processed. 
+      - `compare`: An optional string stating how to treat the constraints.
 
 ### Constraints
 
@@ -132,9 +132,18 @@ Supposing you have a WordPress database and you need to modify certain meta, be 
     }
   ]
 }
-
 ```
 
+#### Compare rules
+Constraints allow the user to define rules for how to treat the comparison value. The following rules are supported:
+
+**PS: Remember that comparison rules are first come first serve, so as soon as a rule that would negate the anonymization of a field is found, it will short-circuit any further rules.**
+
+- `like`: The default behavior. The SQL value must be equal to the constraint `value` field.
+- `not like`: The SQL value must not be equal to the constraint `value` field.
+- `regex`: The SQL value must match the regex string given in the `value` field.
+- `regex not like`: The inverse of `regex`, and requires the regex patter to not match the SQL value.
+- 
 ### Field Types
 
 Each column stores a certain type of data, be it a name, username, email, etc. The `type` property in the config is used to define the type of data stored, and ultimately the type of random data to be inserted into the field. [https://github.com/dmgk/faker](https://github.com/dmgk/faker) is used for generating the fake data. These are the types currently supported:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Constraints allow the user to define rules for how to treat the comparison value
 - `not like`: The SQL value must not be equal to the constraint `value` field.
 - `regex`: The SQL value must match the regex string given in the `value` field.
 - `regex not like`: The inverse of `regex`, and requires the regex patter to not match the SQL value.
-- 
+
 ### Field Types
 
 Each column stores a certain type of data, be it a name, username, email, etc. The `type` property in the config is used to define the type of data stored, and ultimately the type of random data to be inserted into the field. [https://github.com/dmgk/faker](https://github.com/dmgk/faker) is used for generating the fake data. These are the types currently supported:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The config is composed of many objects in the `patterns` array:
       - `field`: a string representing the name of the field.
       - `position`: the 1-based index of what number column this field represents. For instance, assuming a table with 3 columns `foo`, `bar`, and `baz`, and you wished to modify the `bar` column, this value would be `2`.
       - `value`: string value to match against.
+      - `compare`: An optional string stating how to treat the constraints. Passing `not like` will make it a negative lookup, and if the `value` matches, this line will not be processed. 
 
 ### Constraints
 
@@ -126,7 +127,8 @@ Supposing you have a WordPress database and you need to modify certain meta, be 
     {
       "field": "meta_key",
       "position": 3,
-      "value": "last_ip_address"
+      "value": "last_ip_address",
+      "compare": "like"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supposing you have a WordPress database and you need to modify certain meta, be 
 #### Compare rules
 Constraints allow the user to define rules for how to treat the comparison value. The following rules are supported:
 
-**PS: Remember that comparison rules are first come first serve, so as soon as a rule that would negate the anonymization of a field is found, it will short-circuit any further rules.**
+**PS: Remember that comparison rules are first come first serve, so as soon as a rule that would negate the anonymization of a field is found, it will short-circuit any further rules. You should also try to avoid comapring against other fields, remember that a field you may wish to compare against may already have been modified and no longer give the expected value!**
 
 - `like`: The default behavior. The SQL value must be equal to the constraint `value` field.
 - `not like`: The SQL value must not be equal to the constraint `value` field.

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -366,6 +366,18 @@ func rowObeysConstraints(constraints []config.PatternFieldConstraint, row sqlpar
 			if parsedValue == constraint.Value {
 				return false
 			}
+		case "regex not like":
+			re := regexp.MustCompile(constraint.Value)
+			match := re.MatchString(parsedValue)
+			if match {
+				return false
+			}
+		case "regex":
+			re := regexp.MustCompile(constraint.Value)
+			match := re.MatchString(parsedValue)
+			if !match {
+				return false
+			}
 		case "like",
 			"==",
 			"=":

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -369,6 +369,9 @@ func rowObeysConstraints(constraints []config.PatternFieldConstraint, row sqlpar
 		case "like",
 			"==",
 			"=":
+			if parsedValue != constraint.Value {
+				return false
+			}
 		default:
 			if parsedValue != constraint.Value {
 				return false

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -357,10 +357,22 @@ func rowObeysConstraints(constraints []config.PatternFieldConstraint, row sqlpar
 
 		parsedValue := convertSQLValToString(value)
 		// TODO: Add behing a flag for debugging.
-		//log.Printf("Error: Constraint obediance, parsed value: %s, constraint value: %s.", parsedValue, constraint.Value)
+		//log.Printf("Error: Constraint obediance, parsed value: %s, constraint value: %s, and comparator: %s.", parsedValue, constraint.Value, constraint.Compare)
 
-		if parsedValue != constraint.Value {
-			return false
+		switch constraint.Compare {
+		case "not like",
+			"<>",
+			"!=":
+			if parsedValue == constraint.Value {
+				return false
+			}
+		case "like",
+			"==",
+			"=":
+		default:
+			if parsedValue != constraint.Value {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type PatternFieldConstraint struct {
 	Field    string `json:"field"`
 	Position int    `json:"position"`
 	Value    string `json:"value"`
+	Compare  string `json:"compare"`
 }
 
 // New creates a new Config from flags and environment variables

--- a/internal/embed/files/config.default.json
+++ b/internal/embed/files/config.default.json
@@ -7,13 +7,27 @@
           "field": "user_login",
           "position": 2,
           "type": "username",
-          "constraints": null
+          "constraints": [
+            {
+              "field": "user_login",
+              "position": 2,
+              "value": "myaccount",
+              "compare": "not like"
+            }
+          ]
         },
         {
           "field": "user_pass",
           "position": 3,
           "type": "password",
-          "constraints": null
+          "constraints": [
+            {
+              "field": "user_login",
+              "position": 2,
+              "value": "myaccount",
+              "compare": "not like"
+            }
+          ]
         },
         {
           "field": "user_nicename",


### PR DESCRIPTION
Constraints are used to specifically state if am entry should be anonymized, but there are cases where the opposite scenario is needed, where an explicit declaration should _not_ be anonymized.

This PR introduces the concept of negative constraints, specifically `not like` (or just `not` and similar shorthands), when a `not` rule is hit, it will not perform anonymization for the given value, this can be useful for example when needing to anonymize, but wanting to keep your username and password for your personal account.

Taking the example above, the following field rule would only replace the username and password for accounts that do **not** have the username _marius_:

```json
{
  "tableName": ".*_users",
  "fields": [
	{
		"field": "user_login",
		"position": 2,
		"type": "username",
		"constraints": [
			{
				"field": "user_login",
				"position": 2,
				"value": "marius",
				"compare": "not like"
			}
		]
	},
	{
		"field": "user_pass",
		"position": 3,
		"type": "password",
		"constraints": [
			{
				"field": "user_login",
				"position": 2,
				"value": "marius",
				"compare": "not like"
			}
		]
	}
}
```

It is of course still possible to mix multiple constraints, but as soon as a rule that would prevent anonymization is found, it will short-circuit the remaining rules.

The example above is bad, because it looks for the user_login and needs it to not match a value, this _could_ potentially suddenly trigger based on an anonymized value put in, and should instead be matched against a later column ( `user_email` in field 5 for example, but left it like this intentionally for emphasis).

In addition to the `not like`, two other entries are also found now: `regex` and `regex not like`. The explicit `not like` variant is because Go regex does not support negative lookahead or lookbehind, so it can not be used to do a negative lookup within a single rule type.