### PR TITLE
Add a new `locale` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ An example config for anonymizing a WordPress database is provided at [`config.e
 
 ```json
 {
+  "locale": "en",
   "patterns": [
     {
       "tableName": "wp_users",
@@ -101,6 +102,7 @@ An example config for anonymizing a WordPress database is provided at [`config.e
 
 The config is composed of many objects in the `patterns` array:
 
+- `locale`: A string declaring what locale the Faker library should use. This is optional and defaults to `en`.
 - `patterns`: an array of objects defining what modifications should be made.
   - `tableName`: the name of the table the data will be stored in (used to parse `INSERT` statements to determine if the query should be modified.). You can also use regex to identify the relevant tables, required for multisite compatibility e.g. `.*_comments`.
   - `purge`: Optional `boolean` field, if set to `true` then any `INSERT` query matching the table name will be stripped out, avoiding accidentally including data that can't be anonymized in your final result.

--- a/internal/anonymize/anonymize.go
+++ b/internal/anonymize/anonymize.go
@@ -36,11 +36,21 @@ func Start(version, commit, date string) {
 	// Parse flags for custom config file.
 	configFile, locale := flag.Parse(version, commit, date, config.ProcessName)
 
-	// Set the faker locale.
-	setFakerLocale(*locale)
-
 	// Parse config file.
 	config.ParseConfig(*configFile)
+
+	// Set the locale to be the flag value if it was passed.
+	if *locale != "" {
+		config.Locale = *locale
+	}
+
+	// If no locale is defined in the config file or flag, set it to English by default.
+	if config.Locale == "" {
+		config.Locale = "en"
+	}
+
+	// Set the faker locale.
+	setFakerLocale(config.Locale)
 
 	// Error if Stdin is the terminal instead of pipe.
 	stat, _ := os.Stdin.Stat()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Commit      string
 	Date        string
 	WD          string
+	Locale      string          `json:"locale"`
 	Patterns    []ConfigPattern `json:"patterns"`
 }
 

--- a/internal/embed/files/config.default.json
+++ b/internal/embed/files/config.default.json
@@ -1,4 +1,5 @@
 {
+  "locale": "en",
   "patterns": [
     {
       "tableName": ".*_users",

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -25,7 +25,7 @@ Config:
   The anonymizer will use a default config suitable for WordPress, but you can override this by providing your own.`
 
 	flagConfigFile := pflag.String("config", "", "Path to config file.")
-	flagLocale := pflag.String("locale", "en", "Locale for faker data.")
+	flagLocale := pflag.String("locale", "", "Locale for faker data.")
 	flagHelp := pflag.BoolP("help", "h", false, "")
 
 	pflag.Parse()


### PR DESCRIPTION
This new config file entry compliments the `--locale` flag introduced in 9daf83736e79321a2e6262f92b4a191c8e0d4c1f, and allows a config file to pre-define which language should be used for the Faker data.

The CLI flag will take priority, as it's a conscious decision made by the command user at the given time though.